### PR TITLE
Add tests for cs multiple calculations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dots_infrastructure"
-version = "0.1.9"
+version = "0.2.5"
 authors = [
   { name="Leo van Schooten", email="l.g.t.v.schooten@tue.nl" },
 ]

--- a/src/dots_infrastructure/DataClasses.py
+++ b/src/dots_infrastructure/DataClasses.py
@@ -29,16 +29,7 @@ class CalculationServiceOutput:
     helics_publication : h.HelicsPublication = None
 
 @dataclass
-class HelicsFederateInformation:
-    time_period_in_seconds : float
-    time_request_type : TimeRequestType
-    offset : int
-    uninterruptible : bool
-    wait_for_current_time_update : bool
-    terminate_on_error : bool
-
-@dataclass
-class HelicsMessageFederateInformation(HelicsFederateInformation):
+class HelicsMessageFederateInformation:
     endpoint_name : str
 
 @dataclass
@@ -57,11 +48,18 @@ class PublicationDescription:
     data_type : h.HelicsDataType
 
 @dataclass
-class HelicsCalculationInformation(HelicsFederateInformation):
+class HelicsCalculationInformation:
+    time_period_in_seconds : float
+    offset : int
+    uninterruptible : bool
+    wait_for_current_time_update : bool
+    terminate_on_error : bool
     calculation_name : str
     inputs : List[SubscriptionDescription]
     outputs : List[PublicationDescription]
     calculation_function : any
+    time_delta : float = 0
+    time_request_type : TimeRequestType = TimeRequestType.PERIOD
 
 @dataclass
 class SimulatorConfiguration:

--- a/src/dots_infrastructure/EsdlHelper.py
+++ b/src/dots_infrastructure/EsdlHelper.py
@@ -47,7 +47,9 @@ class EsdlHelper:
         if calc_service_name:
             input_descriptions = [input_description for input_description in input_descriptions if input_description.esdl_type == calc_service_name]
             for input_description in input_descriptions:
-                subscriptions.append(CalculationServiceInput(input_description.esdl_type, input_description.input_name, connected_asset.id, input_description.input_unit, input_description.input_type, simulator_asset.id))
+                new_input = CalculationServiceInput(input_description.esdl_type, input_description.input_name, connected_asset.id, input_description.input_unit, input_description.input_type, simulator_asset.id)
+                new_input.helics_sub_key = f'{new_input.esdl_asset_type}/{new_input.input_name}/{new_input.input_esdl_id}'
+                subscriptions.append(new_input)
     
     def add_calc_services_from_ports(
         self,

--- a/src/dots_infrastructure/HelicsFederateHelpers.py
+++ b/src/dots_infrastructure/HelicsFederateHelpers.py
@@ -8,7 +8,7 @@ from esdl import esdl
 
 from dots_infrastructure import Common
 from dots_infrastructure.Constants import TimeRequestType
-from dots_infrastructure.DataClasses import CalculationServiceInput, CalculationServiceOutput, HelicsCalculationInformation, HelicsFederateInformation, HelicsMessageFederateInformation, SimulatorConfiguration, TimeStepInformation
+from dots_infrastructure.DataClasses import CalculationServiceInput, CalculationServiceOutput, HelicsCalculationInformation, HelicsMessageFederateInformation, PublicationDescription, SubscriptionDescription, TimeStepInformation
 from dots_infrastructure.EsdlHelper import EsdlHelper
 from dots_infrastructure.Logger import LOGGER
 from dots_infrastructure import CalculationServiceHelperFunctions
@@ -19,18 +19,22 @@ class HelicsFederateExecutor:
     def __init__(self):
         self.simulator_configuration = CalculationServiceHelperFunctions.get_simulator_configuration_from_environment()
 
-    def init_federate_info(self, info : HelicsFederateInformation, simulation_config : SimulatorConfiguration):
+    def init_default_federate_info(self):
         federate_info = h.helicsCreateFederateInfo()
-        h.helicsFederateInfoSetCoreName(federate_info, self.simulator_configuration.model_id) # might have to set different core names for esdl and calculation core
         h.helicsFederateInfoSetBroker(federate_info, self.simulator_configuration.broker_ip)
         h.helicsFederateInfoSetBrokerPort(federate_info, self.simulator_configuration.broker_port)
+        h.helicsFederateInfoSetCoreType(federate_info, h.HelicsCoreType.ZMQ)
+        h.helicsFederateInfoSetIntegerProperty(federate_info, h.HelicsProperty.INT_LOG_LEVEL, self.simulator_configuration.log_level)
+        return federate_info
+
+    def init_calculation_service_federate_info(self, info : HelicsCalculationInformation):
+        federate_info = self.init_default_federate_info()
         h.helicsFederateInfoSetTimeProperty(federate_info, h.HelicsProperty.TIME_PERIOD, info.time_period_in_seconds)
+        h.helicsFederateInfoSetTimeProperty(federate_info, h.HelicsProperty.TIME_DELTA, info.time_delta)
         h.helicsFederateInfoSetTimeProperty(federate_info, h.HelicsProperty.TIME_OFFSET, info.offset)
         h.helicsFederateInfoSetFlagOption(federate_info, h.HelicsFederateFlag.UNINTERRUPTIBLE, info.uninterruptible)
         h.helicsFederateInfoSetFlagOption(federate_info, h.HelicsFederateFlag.WAIT_FOR_CURRENT_TIME_UPDATE, info.wait_for_current_time_update)
         h.helicsFederateInfoSetFlagOption(federate_info, h.HelicsFlag.TERMINATE_ON_ERROR, info.terminate_on_error)
-        h.helicsFederateInfoSetCoreType(federate_info, h.HelicsCoreType.ZMQ)
-        h.helicsFederateInfoSetIntegerProperty(federate_info, h.HelicsProperty.INT_LOG_LEVEL, simulation_config.log_level)
         return federate_info
 
 class HelicsEsdlMessageFederateExecutor(HelicsFederateExecutor):
@@ -39,7 +43,7 @@ class HelicsEsdlMessageFederateExecutor(HelicsFederateExecutor):
         self.helics_message_federate_information = info
 
     def init_federate(self):
-        federate_info = self.init_federate_info(self.helics_message_federate_information, self.simulator_configuration)
+        federate_info = self.init_default_federate_info()
         self.message_federate = h.helicsCreateMessageFederate(f"{self.simulator_configuration.model_id}", federate_info)
         self.message_enpoint = h.helicsFederateRegisterEndpoint(self.message_federate, self.helics_message_federate_information.endpoint_name)
 
@@ -58,15 +62,16 @@ class HelicsCombinationFederateExecutor(HelicsFederateExecutor):
         super().__init__()
         self.input_dict : dict[str, List[CalculationServiceInput]] = {}
         self.output_dict : dict[str, List[CalculationServiceOutput]] = {}
-        self.helics_value_federate_info = info
+        self.helics_combination_federate_info = info
         self.energy_system : esdl.EnergySystem = None
         self.combination_federate : h.HelicsCombinationFederate = None
         self.commands_message_enpoint : h.HelicsEndpoint = None
 
-    def init_outputs(self, info : HelicsCalculationInformation, combination_federate : h.HelicsCombinationFederate):
-        outputs = CalculationServiceHelperFunctions.generate_publications_from_value_descriptions(info.outputs, self.simulator_configuration)
+    def init_outputs(self, pubs : List[PublicationDescription], combination_federate : h.HelicsCombinationFederate):
+        outputs = CalculationServiceHelperFunctions.generate_publications_from_value_descriptions(pubs, self.simulator_configuration)
         for output in outputs:
             key = f'{output.esdl_asset_type}/{output.output_name}/{output.output_esdl_id}'
+            LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Registering publication with key: {key}")
             if output.global_flag:
                 pub = h.helicsFederateRegisterGlobalPublication(combination_federate, key, output.output_type, output.output_unit)
             else:
@@ -77,38 +82,42 @@ class HelicsCombinationFederateExecutor(HelicsFederateExecutor):
             else:
                 self.output_dict[output.output_esdl_id] = [output]
 
-    def init_inputs(self, info : HelicsCalculationInformation, esdl_helper : EsdlHelper, combination_federate : h.HelicsCombinationFederate):
+    def init_inputs(self, subs : List[SubscriptionDescription], esdl_helper : EsdlHelper, combination_federate : h.HelicsCombinationFederate):
         inputs : List[CalculationServiceInput] = []
         for esdl_id in self.simulator_configuration.esdl_ids:
-            inputs_for_esdl_object = esdl_helper.get_connected_input_esdl_objects(esdl_id, self.simulator_configuration.calculation_services, info.inputs)
-            inputs.extend(inputs_for_esdl_object)
+            inputs_for_esdl_object = esdl_helper.get_connected_input_esdl_objects(esdl_id, self.simulator_configuration.calculation_services, subs)
+            self.remove_duplicate_subscriptions_and_update_inputs(inputs, inputs_for_esdl_object)
             self.input_dict[esdl_id] = inputs_for_esdl_object
 
         for input in inputs:
-            sub_key = f'{input.esdl_asset_type}/{input.input_name}/{input.input_esdl_id}'
-            LOGGER.debug(f"Subscribing to publication with key: {sub_key}")
-            sub = h.helicsFederateRegisterSubscription(combination_federate, sub_key, input.input_unit)
+            LOGGER.debug(f"[{self.combination_federate.name}] Subscribing to publication with key: {input.helics_sub_key}")
+            sub = h.helicsFederateRegisterSubscription(combination_federate, input.helics_sub_key, input.input_unit)
             input.helics_input = sub
-            input.helics_sub_key = sub_key
 
         self.commands_message_enpoint = h.helicsFederateRegisterEndpoint(combination_federate, "commands")
 
+    def remove_duplicate_subscriptions_and_update_inputs(self, inputs : List[CalculationServiceInput], inputs_for_esdl_object : List[CalculationServiceInput]):
+        to_remove = []
+        for i, new_input in enumerate(inputs_for_esdl_object):
+            existing_input = next((input for input in inputs if input.helics_sub_key == new_input.helics_sub_key), None)
+            if existing_input:
+                inputs_for_esdl_object[i] = existing_input
+            else:
+                inputs.append(new_input)
+
     def init_federate(self, esdl_helper : EsdlHelper):
-
-        federate_info = self.init_federate_info(self.helics_value_federate_info, self.simulator_configuration)
-        combination_federate = h.helicsCreateCombinationFederate(f"{self.simulator_configuration.model_id}/{self.helics_value_federate_info.calculation_name}", federate_info)
-
-        self.init_inputs(self.helics_value_federate_info, esdl_helper, combination_federate)
-        self.init_outputs(self.helics_value_federate_info, combination_federate)
-        self.combination_federate = combination_federate
+        federate_info = self.init_calculation_service_federate_info(self.helics_combination_federate_info)
+        self.combination_federate = h.helicsCreateCombinationFederate(f"{self.simulator_configuration.model_id}/{self.helics_combination_federate_info.calculation_name}", federate_info)
+        self.init_inputs(self.helics_combination_federate_info.inputs, esdl_helper, self.combination_federate)
+        self.init_outputs(self.helics_combination_federate_info.outputs, self.combination_federate)
         self.energy_system = esdl_helper.energy_system
 
     def get_helics_value(self, helics_sub : CalculationServiceInput):
-        LOGGER.debug(f"Getting value for subscription: {helics_sub.input_name} with type: {helics_sub.input_type}")
+        ret_val = None
         input_type = helics_sub.input_type
         sub = helics_sub.helics_input
-        ret_val = None
         if h.helicsInputIsUpdated(sub):
+            LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Getting value for subscription: {helics_sub.helics_sub_key} with type: {helics_sub.input_type} updated time: {h.helicsInputLastUpdateTime(sub)}")
             if input_type == h.HelicsDataType.BOOLEAN:
                 ret_val = h.helicsInputGetBoolean(sub)
             elif input_type == h.HelicsDataType.COMPLEX_VECTOR:
@@ -135,10 +144,11 @@ class HelicsCombinationFederateExecutor(HelicsFederateExecutor):
                 ret_val = h.helicsInputGetBytes(sub)
             else:
                 raise ValueError("Unsupported Helics Data Type")
+            LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Got value: {ret_val} from {helics_sub.helics_sub_key}")
         return ret_val
 
     def publish_helics_value(self, helics_output : CalculationServiceOutput, value):
-        LOGGER.debug(f"Publishing value: {value} for publication: {helics_output.output_name} with type: {helics_output.output_type}")
+        LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Publishing value: {value} for publication: {helics_output.helics_publication.name} with type: {helics_output.output_type}")
         pub = helics_output.helics_publication
         output_type = helics_output.output_type
         if output_type == h.HelicsDataType.BOOLEAN:
@@ -167,19 +177,31 @@ class HelicsCombinationFederateExecutor(HelicsFederateExecutor):
             h.helicsPublicationPublishBytes(pub, value)
         else:
             raise ValueError("Unsupported Helics Data Type")
+        
+    def finalize_simulation(self):
+        if self.helics_combination_federate_info.time_request_type == TimeRequestType.PERIOD:
+            LOGGER.info(f"Requesting max time for federate: {h.helicsFederateGetName(self.combination_federate)}")
+            h.helicsFederateRequestTime(self.combination_federate, h.HELICS_TIME_MAXTIME)
+        Common.destroy_federate(self.combination_federate)
 
     def start_combination_federate(self):
         self.enter_simulation_loop()
-        Common.destroy_federate(self.combination_federate)
-
-    def _compute_time_step_number(self, granted_time : h.HelicsTime, period : float):
-        if period == 0:
-            raise Exception(f"Period cannot be zero for calculation {self.helics_value_federate_info.calculation_name}")
-        return int(math.floor(granted_time / period))
-
-    def _get_calculation_service_max_timestamp(self, simulation_duration_in_seconds : int, period : float):
-        return int(math.floor(simulation_duration_in_seconds / period))
+        self.finalize_simulation()
     
+    def initialize_and_start_federate(self, esdl_helper : EsdlHelper):
+        LOGGER.debug(f"[{self.simulator_configuration.model_id}/{self.helics_combination_federate_info.calculation_name}] Initializing federate")
+        self.init_federate(esdl_helper)
+        LOGGER.debug(f"[{self.simulator_configuration.model_id}/{self.helics_combination_federate_info.calculation_name}] Starting federate")
+        self.start_combination_federate()
+
+    def _compute_time_step_number(self, time_of_timestep_to_compute):
+        ret_val = 0
+        if self.helics_combination_federate_info.time_request_type == TimeRequestType.PERIOD:
+            ret_val = int(math.floor(time_of_timestep_to_compute / self.helics_combination_federate_info.time_period_in_seconds))
+        elif self.helics_combination_federate_info.time_request_type == TimeRequestType.ON_INPUT:
+            ret_val = int(math.floor(time_of_timestep_to_compute / self.helics_combination_federate_info.time_delta))
+        return ret_val
+
     def _init_calculation_params(self):
         ret_val = {}
         for esdl_id in self.simulator_configuration.esdl_ids:
@@ -189,66 +211,69 @@ class HelicsCombinationFederateExecutor(HelicsFederateExecutor):
                     ret_val[helics_input.helics_sub_key] = None
         return ret_val
 
+    def _publish_outputs(self, esdl_id, pub_values):
+        if len(self.helics_combination_federate_info.outputs) > 0:
+            outputs = self.output_dict[esdl_id]
+            for output in outputs:
+                value_to_publish = pub_values[output.output_name]
+                self.publish_helics_value(output, value_to_publish)
+
+    def _gather_new_inputs(self, calculation_params, esdl_id):
+        if esdl_id in self.input_dict:
+            inputs = self.input_dict[esdl_id]
+            for helics_input in inputs:
+                if calculation_params[helics_input.helics_sub_key] == None:
+                    calculation_params[helics_input.helics_sub_key] = self.get_helics_value(helics_input)
+
+    def _get_request_time(self, granted_time):
+        if self.helics_combination_federate_info.time_request_type == TimeRequestType.PERIOD:
+            requested_time = granted_time + self.helics_combination_federate_info.time_period_in_seconds
+        if self.helics_combination_federate_info.time_request_type == TimeRequestType.ON_INPUT:
+            requested_time = h.HELICS_TIME_MAXTIME
+        return requested_time
+
     def enter_simulation_loop(self):
-        LOGGER.info(f"Entering HELICS execution mode {self.helics_value_federate_info.calculation_name}")
+        LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Entering HELICS execution mode {self.helics_combination_federate_info.calculation_name}")
         h.helicsFederateEnterExecutingMode(self.combination_federate)
-        LOGGER.info(f"Entered HELICS execution mode {self.helics_value_federate_info.calculation_name}")
-        federate_name = h.helicsFederateGetName(self.combination_federate)
+        LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Entered HELICS execution mode {self.helics_combination_federate_info.calculation_name}")
 
         total_interval = self.simulator_configuration.simulation_duration_in_seconds
-        update_interval = int(h.helicsFederateGetTimeProperty(self.combination_federate, h.HELICS_PROPERTY_TIME_PERIOD))
-        max_time_step_number = self._get_calculation_service_max_timestamp(total_interval, update_interval)
+        max_time_step_number = self._compute_time_step_number(total_interval)
         granted_time = 0
         terminate_requested = False
         calculation_params = self._init_calculation_params()
         while granted_time < total_interval and not terminate_requested:
-            requested_time = self._get_request_time(update_interval, granted_time)
-            LOGGER.debug(f"Requesting time: {requested_time} for calculation {self.helics_value_federate_info.calculation_name}")
+
+            requested_time = self._get_request_time(granted_time)
+            LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Requesting time: {requested_time} for calculation {self.helics_combination_federate_info.calculation_name}")
             granted_time = h.helicsFederateRequestTime(self.combination_federate, requested_time)
-            LOGGER.debug(f"Time granted: {granted_time} for calculation {self.helics_value_federate_info.calculation_name}")
+            LOGGER.debug(f"[{h.helicsFederateGetName(self.combination_federate)}] Time granted: {granted_time} for calculation {self.helics_combination_federate_info.calculation_name}")
 
             simulator_time = self.simulator_configuration.start_time + timedelta(seconds = granted_time)
-            time_step_number = self._compute_time_step_number(granted_time, update_interval)
+            time_step_number = self._compute_time_step_number(granted_time)
             time_step_information = TimeStepInformation(time_step_number, max_time_step_number)
+
             for esdl_id in self.simulator_configuration.esdl_ids:
                 if not terminate_requested:
-                    if esdl_id in self.input_dict:
-                        inputs = self.input_dict[esdl_id]
-                        for helics_input in inputs:
-                            if calculation_params[helics_input.helics_sub_key] == None:
-                                calculation_params[helics_input.helics_sub_key] = self.get_helics_value(helics_input)
+                    self._gather_new_inputs(calculation_params, esdl_id)
                     try:
                         if CalculationServiceHelperFunctions.dictionary_has_values_for_all_keys(calculation_params):
-                            LOGGER.info(f"Executing calculation {self.helics_value_federate_info.calculation_name} for esdl_id {esdl_id} at time {granted_time}")
-                            pub_values = self.helics_value_federate_info.calculation_function(calculation_params, simulator_time, time_step_information, esdl_id, self.energy_system)
-                            LOGGER.info(f"Finished calculation {self.helics_value_federate_info.calculation_name} for esdl_id {esdl_id} at time {granted_time}")
-                            LOGGER.debug(f"Publishing Values: {self.output_dict}")
-
-                            if len(self.helics_value_federate_info.outputs) > 0:
-                                outputs = self.output_dict[esdl_id]
-                                for output in outputs:
-                                    value_to_publish = pub_values[output.output_name]
-                                    self.publish_helics_value(output, value_to_publish)
+                            LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Executing calculation {self.helics_combination_federate_info.calculation_name} for esdl_id {esdl_id} at time {granted_time}")
+                            pub_values = self.helics_combination_federate_info.calculation_function(calculation_params, simulator_time, time_step_information, esdl_id, self.energy_system)
+                            LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Finished calculation {self.helics_combination_federate_info.calculation_name} for esdl_id {esdl_id} at time {granted_time}")
+                            self._publish_outputs(esdl_id, pub_values)
                             calculation_params = CalculationServiceHelperFunctions.clear_dictionary_values(calculation_params)
                     except Exception:
-                        LOGGER.info(f"Exception occurred for esdl_id {esdl_id} at time {granted_time} terminating simulation...")
+                        LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Exception occurred for esdl_id {esdl_id} at time {granted_time} terminating simulation...")
                         traceback.print_exc()
                         Common.terminate_simulation(self.combination_federate, self.commands_message_enpoint)
                         terminate_requested = True
 
-            LOGGER.info(f"Finished {granted_time} of {total_interval} and terminate requested {terminate_requested} for federate with name {federate_name}")
+            LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Finished {granted_time} of {total_interval} and terminate requested {terminate_requested}")
 
             terminate_requested = Common.terminate_requested_at_commands_endpoint(self.commands_message_enpoint)
 
-        LOGGER.info(f"Finalizing federate at {granted_time} of {total_interval} and terminate requested {terminate_requested} with name {federate_name}")
-
-    def _get_request_time(self, update_interval, granted_time):
-        requested_time = 0
-        if self.helics_value_federate_info.time_request_type == TimeRequestType.PERIOD and granted_time > 0:
-            requested_time = granted_time + update_interval
-        if self.helics_value_federate_info.time_request_type == TimeRequestType.ON_INPUT:
-            requested_time = h.HELICS_TIME_MAXTIME
-        return requested_time
+        LOGGER.info(f"[{h.helicsFederateGetName(self.combination_federate)}] Finalizing federate at {granted_time} of {total_interval} and terminate requested {terminate_requested}")
 
 class HelicsSimulationExecutor:
 
@@ -263,10 +288,14 @@ class HelicsSimulationExecutor:
             info.inputs = []
         if info.outputs == None:
             info.outputs = []
+        if len(info.inputs) > 0:
+            info.time_delta = info.time_period_in_seconds
+            info.time_period_in_seconds = 0
+            info.time_request_type = TimeRequestType.ON_INPUT
         self.calculations.append(HelicsCombinationFederateExecutor(info))
 
     def _get_esdl_from_so(self):
-        esdl_message_federate = HelicsEsdlMessageFederateExecutor(HelicsMessageFederateInformation(60, TimeRequestType.ON_INPUT, 60, False, False, True, 'esdl'))
+        esdl_message_federate = HelicsEsdlMessageFederateExecutor(HelicsMessageFederateInformation('esdl'))
         esdl_message_federate.init_federate()
         esdl_helper = esdl_message_federate.wait_for_esdl_file()
         return esdl_helper
@@ -289,9 +318,7 @@ class HelicsSimulationExecutor:
         esdl_helper = self.init_simulation()
         self.exe = ThreadPoolExecutor(len(self.calculations))
         for calculation in self.calculations:
-            calculation.init_federate(esdl_helper)
-        for calculation in self.calculations:
-            self.exe.submit(calculation.start_combination_federate)
+            self.exe.submit(calculation.initialize_and_start_federate, esdl_helper)
 
     def stop_simulation(self):
         self.exe.shutdown()

--- a/test/TestInputExtraction.py
+++ b/test/TestInputExtraction.py
@@ -23,8 +23,8 @@ class TestParse(unittest.TestCase):
         ]
 
         expected_input_descriptions = [
-            CalculationServiceInput("PVInstallation", "PV_Dispatch", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
-            CalculationServiceInput("PVInstallation", "PV_Dispatch", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch/176af591-6d9d-4751-bb0f-fac7e99b1c3d"),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch/b8766109-5328-416f-9991-e81a5cada8a6")
         ]
 
         calculation_services = [
@@ -48,7 +48,7 @@ class TestParse(unittest.TestCase):
         ]
 
         expected_input_descriptions = [
-            CalculationServiceInput("EnergyMarket", "DA_Price", 'b612fc89-a752-4a30-84bb-81ebffc56b50', "EUR", h.HelicsDataType.DOUBLE, simulator_esdl_id)
+            CalculationServiceInput("EnergyMarket", "DA_Price", 'b612fc89-a752-4a30-84bb-81ebffc56b50', "EUR", h.HelicsDataType.DOUBLE, simulator_esdl_id, "EnergyMarket/DA_Price/b612fc89-a752-4a30-84bb-81ebffc56b50")
         ]
 
         calculation_services = [
@@ -75,14 +75,38 @@ class TestParse(unittest.TestCase):
         ]
 
         expected_input_descriptions = [
-            CalculationServiceInput("PVInstallation", "PV_Dispatch", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
-            CalculationServiceInput("PVInstallation", "PV_Dispatch2", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
-            CalculationServiceInput("PVInstallation", "PV_Dispatch", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
-            CalculationServiceInput("PVInstallation", "PV_Dispatch2", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch/176af591-6d9d-4751-bb0f-fac7e99b1c3d"),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch2", '176af591-6d9d-4751-bb0f-fac7e99b1c3d', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch2/176af591-6d9d-4751-bb0f-fac7e99b1c3d"),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch/b8766109-5328-416f-9991-e81a5cada8a6"),
+            CalculationServiceInput("PVInstallation", "PV_Dispatch2", 'b8766109-5328-416f-9991-e81a5cada8a6', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "PVInstallation/PV_Dispatch2/b8766109-5328-416f-9991-e81a5cada8a6"),
         ]
 
         calculation_services = [
             "PVInstallation"
+        ]
+
+        # Execute
+        inputs = esdl_helper.get_connected_input_esdl_objects(simulator_esdl_id, calculation_services, subscription_descriptions)
+
+        # Assert correct assets are extracted from esdl file
+        self.assertListEqual(expected_input_descriptions, inputs)
+
+    def test_given_non_energy_entity_subscriptions_are_correctly_extracted(self):
+        # Arrange
+        simulator_esdl_id = '02fafa20-a1bd-488e-a4db-f3c0ca7ff51a'
+
+        esdl_helper = EsdlHelper(self.encoded_base64_esdl)
+
+        subscription_descriptions = [
+            SubscriptionDescription("EConnection", "EConnectionDispatch", "W", h.HelicsDataType.DOUBLE)
+        ]
+
+        expected_input_descriptions = [
+            CalculationServiceInput("EConnection", "EConnectionDispatch", 'f006d594-0743-4de5-a589-a6c2350898da', "W", h.HelicsDataType.DOUBLE, simulator_esdl_id, "EConnection/EConnectionDispatch/f006d594-0743-4de5-a589-a6c2350898da")
+        ]
+
+        calculation_services = [
+            "EConnection"
         ]
 
         # Execute

--- a/test/TestSimulationRun.py
+++ b/test/TestSimulationRun.py
@@ -1,6 +1,5 @@
 import base64
 from datetime import datetime
-import random
 from threading import Thread
 from typing import List
 import unittest
@@ -9,7 +8,6 @@ import helics as h
 from unittest.mock import MagicMock
 
 from dots_infrastructure import CalculationServiceHelperFunctions
-from dots_infrastructure.Constants import TimeRequestType
 from dots_infrastructure.DataClasses import EsdlId, HelicsCalculationInformation, PublicationDescription, SimulatorConfiguration, SubscriptionDescription, TimeStepInformation
 from dots_infrastructure.EsdlHelper import EsdlHelper
 from dots_infrastructure.HelicsFederateHelpers import HelicsEsdlMessageFederateExecutor, HelicsSimulationExecutor
@@ -17,12 +15,10 @@ from dots_infrastructure.Logger import LOGGER
 from dots_infrastructure.test_infra.InfluxDBMock import InfluxDBMock
 from esdl.esdl import EnergySystem
 
-LOGGER.setLevel("DEBUG")
-
 BROKER_TEST_PORT = 23404
 START_DATE_TIME = datetime(2024, 1, 1, 0, 0, 0)
-SIMULATION_DURATION_IN_SECONDS = 960
-CALCULATION_SERVICES = ["PVInstallation", "EConnection", "EnergyMarket"]
+SIMULATION_DURATION_IN_SECONDS = 120
+CALCULATION_SERVICES = ["PVInstallation", "EConnection", "EnergyMarket", "Carriers"]
 STR_INFLUX_TEST_PORT = "test-port"
 INFLUX_USERNAME = "test-username"
 INFLUX_PASSWORD = "test-password"
@@ -47,7 +43,7 @@ class CalculationServicePVDispatch(HelicsSimulationExecutor):
         ]
         subscriptions_values = []
         pv_installation_period_in_seconds = 30
-        info = HelicsCalculationInformation(pv_installation_period_in_seconds, TimeRequestType.PERIOD, 0, False, False, True, "pvdispatch_calculation", subscriptions_values, publictations_values, self.pvdispatch_calculation)
+        info = HelicsCalculationInformation(pv_installation_period_in_seconds, 0, False, False, True, "pvdispatch_calculation", subscriptions_values, publictations_values, self.pvdispatch_calculation)
         self.add_calculation(info)
 
 
@@ -55,6 +51,29 @@ class CalculationServicePVDispatch(HelicsSimulationExecutor):
         ret_val = {}
         ret_val["PV_Dispatch"] = time_step_number.current_time_step_number
         self.influx_connector.set_time_step_data_point(esdl_id, "PV_Dispatch", simulation_time, ret_val["PV_Dispatch"])
+        return ret_val
+
+class CalculationServicePVDispatchMultipleOutputs(HelicsSimulationExecutor):
+    def __init__(self):
+        CalculationServiceHelperFunctions.get_simulator_configuration_from_environment = simulator_environment_e_pv
+        super().__init__()
+        self.influx_connector = InfluxDBMock()
+        publictations_values = [
+            PublicationDescription(True, "PVInstallation", "PV_Dispatch", "W", h.HelicsDataType.DOUBLE),
+            PublicationDescription(True, "PVInstallation", "PV_Dispatch2", "W", h.HelicsDataType.DOUBLE)
+        ]
+        subscriptions_values = []
+        pv_installation_period_in_seconds = 30
+        info = HelicsCalculationInformation(pv_installation_period_in_seconds, 0, True, False, True, "pvdispatch_calculation", subscriptions_values, publictations_values, self.pvdispatch_calculation)
+        self.add_calculation(info)
+
+
+    def pvdispatch_calculation(self, param_dict : dict, simulation_time : datetime, time_step_number : TimeStepInformation, esdl_id : EsdlId, energy_system : EnergySystem):
+        ret_val = {}
+        ret_val["PV_Dispatch"] = time_step_number.current_time_step_number
+        ret_val["PV_Dispatch2"] = time_step_number.current_time_step_number
+        self.influx_connector.set_time_step_data_point(esdl_id, "PV_Dispatch", simulation_time, ret_val["PV_Dispatch"])
+        self.influx_connector.set_time_step_data_point(esdl_id, "PV_Dispatch2", simulation_time, ret_val["PV_Dispatch2"])
         return ret_val
 
 def simulator_environment_energy_market():
@@ -74,7 +93,7 @@ class CalculationServiceMarketService(HelicsSimulationExecutor):
 
         energy_market_period_in_seconds = 60
 
-        calculation_information = HelicsCalculationInformation(energy_market_period_in_seconds, TimeRequestType.PERIOD, 0, False, False, True, "EConnectionDispatch", None, publication_values, self.energy_market_price)
+        calculation_information = HelicsCalculationInformation(energy_market_period_in_seconds, 0, False, False, True, "MarketPrice", None, publication_values, self.energy_market_price)
         
         self.add_calculation(calculation_information)
 
@@ -82,7 +101,6 @@ class CalculationServiceMarketService(HelicsSimulationExecutor):
         ret_val = {}
         ret_val["Price"] = time_step_number.current_time_step_number
         return ret_val
-
 
 def simulator_environment_e_connection():
     return SimulatorConfiguration("EConnection", ["f006d594-0743-4de5-a589-a6c2350898da"], "Mock-Econnection", BROKER_IP, BROKER_TEST_PORT, SIMULATION_ID, SIMULATION_DURATION_IN_SECONDS, START_DATE_TIME, INFLUX_HOST, STR_INFLUX_TEST_PORT, INFLUX_USERNAME, INFLUX_PASSWORD, INFLUX_DB_NAME, h.HelicsLogLevel.DEBUG, CALCULATION_SERVICES)
@@ -95,31 +113,27 @@ class CalculationServiceEConnection(HelicsSimulationExecutor):
         self.influx_connector = InfluxDBMock()
         self.calculation_service_initialized = False
 
-        subscriptions_values = [
+        subscriptions_values_dispatch = [
             SubscriptionDescription("PVInstallation", "PV_Dispatch", "W", h.HelicsDataType.DOUBLE)
         ]
 
-        publication_values = [
+        publication_values_dispatch = [
             PublicationDescription(True, "EConnection", "EConnectionDispatch", "W", h.HelicsDataType.DOUBLE)
         ]
 
         e_connection_period_in_seconds = 60
 
-        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, TimeRequestType.ON_INPUT, 0, False, False, True, "EConnectionDispatch", subscriptions_values, publication_values, self.e_connection_dispatch)
+        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, 0, False, False, True, "EConnectionDispatch", subscriptions_values_dispatch, publication_values_dispatch, self.e_connection_dispatch)
         self.add_calculation(calculation_information)
 
-        subscriptions_values = [
+        subscriptions_values_schedule = [
             SubscriptionDescription("PVInstallation", "PV_Dispatch", "W", h.HelicsDataType.DOUBLE),
             SubscriptionDescription("EnergyMarket", "Price", "EUR", h.HelicsDataType.DOUBLE)
         ]
 
-        publication_values = [
-            PublicationDescription(True, "EConnection", "Schedule", "W", h.HelicsDataType.VECTOR)
-        ]
-
         e_connection_period_scedule_in_seconds = 60
 
-        calculation_information_schedule = HelicsCalculationInformation(e_connection_period_scedule_in_seconds, TimeRequestType.ON_INPUT, 0, False, False, True, "EConnectionSchedule", subscriptions_values, publication_values, self.e_connection_da_schedule)
+        calculation_information_schedule = HelicsCalculationInformation(e_connection_period_scedule_in_seconds, 0, False, False, True, "EConnectionSchedule", subscriptions_values_schedule, None, self.e_connection_da_schedule)
         self.add_calculation(calculation_information_schedule)
 
     def init_calculation_service(self, energy_system: EnergySystem):
@@ -140,6 +154,53 @@ class CalculationServiceEConnection(HelicsSimulationExecutor):
         self.influx_connector.set_time_step_data_point(esdl_id, "DAScedule", simulation_time, ret_val["Schedule"])
         return ret_val
 
+def simulator_environment_e_commonity():
+    return SimulatorConfiguration("Carriers", ["02fafa20-a1bd-488e-a4db-f3c0ca7ff51a"], "Mock-Commonity", BROKER_IP, BROKER_TEST_PORT, SIMULATION_ID, SIMULATION_DURATION_IN_SECONDS, START_DATE_TIME, INFLUX_HOST, STR_INFLUX_TEST_PORT, INFLUX_USERNAME, INFLUX_PASSWORD, INFLUX_DB_NAME, h.HelicsLogLevel.DEBUG, CALCULATION_SERVICES)
+
+class CalculationServiceElectricityCommodity(HelicsSimulationExecutor):
+    def __init__(self):
+        CalculationServiceHelperFunctions.get_simulator_configuration_from_environment = simulator_environment_e_commonity
+        super().__init__()
+        self.influx_connector = InfluxDBMock()
+
+        subscriptions_values = [
+            SubscriptionDescription("EConnection", "EConnectionDispatch", "W", h.HelicsDataType.DOUBLE)
+        ]
+
+        e_connection_period_in_seconds = 60
+
+        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, 0, False, False, True, "Loadflow", subscriptions_values, None, self.load_flow)
+        self.add_calculation(calculation_information)
+
+    def load_flow(self, param_dict : dict, simulation_time : datetime, time_step_number : TimeStepInformation, esdl_id : EsdlId, energy_system : EnergySystem):
+        load = CalculationServiceHelperFunctions.get_single_param_with_name(param_dict, "EConnectionDispatch")
+        self.influx_connector.set_time_step_data_point(esdl_id, "load_flow", simulation_time, load)
+
+class CalculationServiceMultiplePvInputsEConnection(HelicsSimulationExecutor):
+    def __init__(self):
+        CalculationServiceHelperFunctions.get_simulator_configuration_from_environment = simulator_environment_e_connection
+        super().__init__()
+        self.influx_connector = InfluxDBMock()
+
+        subscriptions_values = [
+            SubscriptionDescription("PVInstallation", "PV_Dispatch", "W", h.HelicsDataType.DOUBLE),
+            SubscriptionDescription("PVInstallation", "PV_Dispatch2", "W", h.HelicsDataType.DOUBLE)
+        ]
+
+        e_connection_period_in_seconds = 30
+
+        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, 0, False, False, True, "EConnectionDispatch", subscriptions_values, [], self.e_connection_dispatch)
+        self.add_calculation(calculation_information)
+
+    def e_connection_dispatch(self, param_dict : dict, simulation_time : datetime, time_step_number : TimeStepInformation, esdl_id : EsdlId, energy_system : EnergySystem):
+        pv_dispatch = CalculationServiceHelperFunctions.get_single_param_with_name(param_dict, "PV_Dispatch")
+        pv_dispatch2 = CalculationServiceHelperFunctions.get_single_param_with_name(param_dict, "PV_Dispatch2")
+        ret_val = {}
+        ret_val["EConnectionDispatch"] = pv_dispatch
+        self.influx_connector.set_time_step_data_point(esdl_id, "PV_Dispatch", simulation_time, pv_dispatch)
+        self.influx_connector.set_time_step_data_point(esdl_id, "PV_Dispatch2", simulation_time, pv_dispatch2)
+        return ret_val
+
 class CalculationServiceEConnectionException(HelicsSimulationExecutor):
 
     def __init__(self):
@@ -157,7 +218,7 @@ class CalculationServiceEConnectionException(HelicsSimulationExecutor):
 
         e_connection_period_in_seconds = 60
 
-        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, TimeRequestType.PERIOD, 0, False, False, True, "EConnectionDispatch", subscriptions_values, publication_values, self.e_connection_dispatch)
+        calculation_information = HelicsCalculationInformation(e_connection_period_in_seconds, 0, False, False, True, "EConnectionDispatch", subscriptions_values, publication_values, self.e_connection_dispatch)
         self.add_calculation(calculation_information)
 
     def e_connection_dispatch(self, param_dict : dict, simulation_time : datetime, time_step_number : TimeStepInformation, esdl_id : EsdlId, energy_system : EnergySystem):
@@ -175,12 +236,15 @@ class TestSimulation(unittest.TestCase):
 
         self.wait_for_esdl_file = HelicsEsdlMessageFederateExecutor.wait_for_esdl_file
         self.esdl_message_init_federate = HelicsEsdlMessageFederateExecutor.init_federate 
+        self.calculationServiceHelperFunctions_get_simulator_configuration_from_environment = CalculationServiceHelperFunctions.get_simulator_configuration_from_environment
         HelicsEsdlMessageFederateExecutor.wait_for_esdl_file = MagicMock(return_value=EsdlHelper(encoded_base64_esdl))
         HelicsEsdlMessageFederateExecutor.init_federate = MagicMock()
+        LOGGER.setLevel("DEBUG")
 
     def tearDown(self):
         HelicsEsdlMessageFederateExecutor.wait_for_esdl_file = self.wait_for_esdl_file 
         HelicsEsdlMessageFederateExecutor.init_federate = self.esdl_message_init_federate 
+        CalculationServiceHelperFunctions.get_simulator_configuration_from_environment = self.calculationServiceHelperFunctions_get_simulator_configuration_from_environment
 
     def start_broker(self, n_federates):
         self.broker_thread = Thread(target = self.start_helics_broker, args = [ n_federates ])
@@ -189,41 +253,30 @@ class TestSimulation(unittest.TestCase):
     def stop_broker(self):
         self.broker_thread.join()
 
-    def test_simulation_run_starts_correctly(self):
+    def test_given_calculation_with_multiple_outputs_all_outputs_get_published_and_consumed(self):
         # Arrange 
-        self.start_broker(4)
+        self.start_broker(2)
 
-        e_connection_dispatch_period_in_seconds = 60
-        e_connection_period_scedule_in_seconds = 60
-        pv_period = 30
-        expected_data_point_values_dispatch = [i * 2.0 for i in range(1, 17)]
-        expected_data_point_values_schedule = [[i * 2.0 * i, i * 2.0 * i, i * 2.0 * i] for i in range(1, 17)]
+        expected_data_point_values_dispatch = []
+        for i in range(1, 5):
+            expected_data_point_values_dispatch.append(i)
+            expected_data_point_values_dispatch.append(i)
 
         # Execute
-        cs_econnection = CalculationServiceEConnection()
-        cs_dispatch = CalculationServicePVDispatch()
-        cs_market = CalculationServiceMarketService()
+        cs_econnection = CalculationServiceMultiplePvInputsEConnection()
+        cs_dispatch = CalculationServicePVDispatchMultipleOutputs()
 
         cs_econnection.start_simulation()
         cs_dispatch.start_simulation()
-        cs_market.start_simulation()
         cs_econnection.stop_simulation()
         cs_dispatch.stop_simulation()
-        cs_market.stop_simulation()
         self.stop_broker()
 
         # Assert
-        actual_data_point_values_dispatch = [dp.value for dp in cs_econnection.influx_connector.data_points if not isinstance(dp.value, List)]
-        actual_data_point_values_schedule = [dp.value for dp in cs_econnection.influx_connector.data_points if isinstance(dp.value, List)]
+        actual_data_point_values_dispatch = [dp.value for dp in cs_econnection.influx_connector.data_points]
         self.assertListEqual(expected_data_point_values_dispatch, actual_data_point_values_dispatch)
-        self.assertListEqual(expected_data_point_values_schedule, actual_data_point_values_schedule)
-        self.assertEqual(len(cs_econnection.influx_connector.data_points), 
-                         SIMULATION_DURATION_IN_SECONDS / e_connection_dispatch_period_in_seconds + 
-                         SIMULATION_DURATION_IN_SECONDS / e_connection_period_scedule_in_seconds)
-        self.assertEqual(len(cs_dispatch.influx_connector.data_points), SIMULATION_DURATION_IN_SECONDS / pv_period * 2)
-        self.assertTrue(cs_econnection.calculation_service_initialized)
 
-    def test_simulation_run_stops_upon_exception(self):
+    def test_given_exception_occurrs_in_cs_then_simulation_is_termintaed(self):
         # Arrange 
         self.start_broker(2)
         e_connection_dispatch_period_in_seconds = 60
@@ -244,6 +297,46 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(len(cs_econnection.influx_connector.data_points), 0) 
         # 2 pv panels produce data at most 3 times so
         self.assertLessEqual(len(cs_econnection.influx_connector.data_points), 2 * e_connection_dispatch_period_in_seconds / pv_period + 1)
+
+    def test_given_a_set_of_calculation_services_then_simulation_executes_as_expected(self):
+        # Arrange 
+        self.start_broker(5)
+
+        e_connection_dispatch_period_in_seconds = 60
+        e_connection_period_scedule_in_seconds = 60
+        pv_period = 30
+        expected_data_point_values_dispatch = [i * 2.0 for i in range(1, 3)]
+        expected_data_point_values_loadflow = expected_data_point_values_dispatch
+        expected_data_point_values_schedule = [[i * 2.0 * i, i * 2.0 * i, i * 2.0 * i] for i in range(1, 3)]
+
+        # Execute
+        cs_econnection = CalculationServiceEConnection()
+        cs_dispatch = CalculationServicePVDispatch()
+        cs_market = CalculationServiceMarketService()
+        cs_electricity_commodity = CalculationServiceElectricityCommodity()
+
+        cs_econnection.start_simulation()
+        cs_dispatch.start_simulation()
+        cs_market.start_simulation()
+        cs_electricity_commodity.start_simulation()
+        cs_econnection.stop_simulation()
+        cs_dispatch.stop_simulation()
+        cs_market.stop_simulation()
+        cs_electricity_commodity.stop_simulation()
+        self.stop_broker()
+
+        # Assert
+        actual_data_point_values_dispatch = [dp.value for dp in cs_econnection.influx_connector.data_points if not isinstance(dp.value, List)]
+        actual_data_point_values_schedule = [dp.value for dp in cs_econnection.influx_connector.data_points if isinstance(dp.value, List)]
+        actual_data_point_values_loadflow = [dp.value for dp in cs_electricity_commodity.influx_connector.data_points]
+        self.assertListEqual(expected_data_point_values_dispatch, actual_data_point_values_dispatch)
+        self.assertListEqual(expected_data_point_values_schedule, actual_data_point_values_schedule)
+        self.assertListEqual(expected_data_point_values_loadflow, actual_data_point_values_loadflow)
+        self.assertEqual(len(cs_econnection.influx_connector.data_points), 
+                         SIMULATION_DURATION_IN_SECONDS / e_connection_dispatch_period_in_seconds + 
+                         SIMULATION_DURATION_IN_SECONDS / e_connection_period_scedule_in_seconds)
+        self.assertEqual(len(cs_dispatch.influx_connector.data_points), SIMULATION_DURATION_IN_SECONDS / pv_period * 2)
+        self.assertTrue(cs_econnection.calculation_service_initialized)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.esdl
+++ b/test/test.esdl
@@ -9,23 +9,7 @@
     <area xsi:type="esdl:Area" id="757e25b5-908f-4934-a16d-880c63c84406" name="area_title">
       <asset xsi:type="esdl:Bus" name="bus" id="44530afd-832b-4acf-998d-5654359ed813" voltage="400.0">
         <geometry xsi:type="esdl:Point" lat="51.444378637449404" lon="5.326824188232422"/>
-        <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="4c9141e6-4df1-4ed6-97c4-4a7146034ff8" id="bdae0341-c510-4bc6-a6f8-2a564f7a5bf3"/>
         <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="a663919d-43e7-4cd5-8e04-01ed1fd8f7d5" id="072ad846-fa1f-43f5-a67d-a16df3f88d21"/>
-        <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="2978ba34-820e-45dc-bdc8-530ed856c33e" id="ada56a6a-80b2-4542-bb6e-2a475c3a4ac6"/>
-        <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="23c115d9-655d-4249-abb9-4643de97aee3" id="5f139a1a-4415-44a1-866e-9da3eb112485"/>
-        <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="6fcd6063-0b4f-42b7-b1f2-5a4fcbaf7ec8" id="a98ca5f6-3aec-412a-bc69-a9ca02c63181"/>
-      </asset>
-      <asset xsi:type="esdl:Building" name="house0" id="b2a523ae-cb89-44dd-b41f-9fd47aba5c0d">
-        <geometry xsi:type="esdl:Point" lat="51.44473304736181" lon="5.327843427658082"/>
-        <asset xsi:type="esdl:EConnection" name="connection0" id="e1b3dc89-cee8-4f8e-81ce-a0cb6726c17e">
-          <geometry xsi:type="esdl:Point" lat="260.0" lon="52.0" CRS="Simple"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="bdae0341-c510-4bc6-a6f8-2a564f7a5bf3" id="4c9141e6-4df1-4ed6-97c4-4a7146034ff8"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="71a80838-4e6d-4ae2-8358-bd7c2a12386b" id="983c61ea-d305-474a-bada-5886dd49c6f8"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation0" id="1830a516-fae5-4cc7-99bd-6e9a5d175a80" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="415.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="983c61ea-d305-474a-bada-5886dd49c6f8" id="71a80838-4e6d-4ae2-8358-bd7c2a12386b"/>
-        </asset>
       </asset>
       <asset xsi:type="esdl:Building" name="house1" id="00ab1742-0480-4a1d-a668-d09f5bca9e2f">
         <geometry xsi:type="esdl:Point" lat="51.44436826693578" lon="5.327478647232056"/>
@@ -42,87 +26,6 @@
         <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation1" id="b8766109-5328-416f-9991-e81a5cada8a6" panelEfficiency="0.2">
           <geometry xsi:type="esdl:Point" lat="365.0" lon="236.0" CRS="Simple"/>
           <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="33d0e20e-f618-4133-8eab-aa1bbb57e2ea" id="85b715d0-9851-40a4-a432-969245779b2f"/>
-        </asset>
-      </asset>
-      <asset xsi:type="esdl:Building" name="house2" id="9a6f92f2-69db-4435-9730-e37d9f1f61ba">
-        <geometry xsi:type="esdl:Point" lat="51.44400348650976" lon="5.327113866806029"/>
-        <asset xsi:type="esdl:EConnection" name="connection2" id="f3857348-cbd8-4a89-9e37-cbcf67e649d7">
-          <geometry xsi:type="esdl:Point" lat="260.0" lon="52.0" CRS="Simple"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="ada56a6a-80b2-4542-bb6e-2a475c3a4ac6" id="2978ba34-820e-45dc-bdc8-530ed856c33e"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="a966c1c9-2abf-407c-b8e7-8784ab8c77ba" id="cdb6700a-a730-4409-9830-70a61bc4781c"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="288403a8-25fc-4bf9-a975-6592ab84e12b" id="92627339-be9c-4467-afe8-7e0ac2ab04ed"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="fdd2f313-34fc-4919-a6d2-8a9df7997ae5" id="bc345447-59bb-4fe3-9b35-d88cc56c1b7c"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation2" id="529aca74-b8da-4489-9d76-1b2320aa3f40" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="415.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="cdb6700a-a730-4409-9830-70a61bc4781c" id="a966c1c9-2abf-407c-b8e7-8784ab8c77ba"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation2" id="2113dfc3-08d4-40df-8e76-9e53a55d3342" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="365.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="92627339-be9c-4467-afe8-7e0ac2ab04ed" id="288403a8-25fc-4bf9-a975-6592ab84e12b"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation2" id="fdfd4af3-570b-4b81-ac5f-46ca1e687764" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="315.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="bc345447-59bb-4fe3-9b35-d88cc56c1b7c" id="fdd2f313-34fc-4919-a6d2-8a9df7997ae5"/>
-        </asset>
-      </asset>
-      <asset xsi:type="esdl:Building" name="house3" id="d7a38cbc-8eff-4da0-9210-e3937b356645">
-        <geometry xsi:type="esdl:Point" lat="51.44363870608373" lon="5.326749086380003"/>
-        <asset xsi:type="esdl:EConnection" name="connection3" id="e8711505-2744-48e9-b863-b7bd58722d3b">
-          <geometry xsi:type="esdl:Point" lat="260.0" lon="52.0" CRS="Simple"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="5f139a1a-4415-44a1-866e-9da3eb112485" id="23c115d9-655d-4249-abb9-4643de97aee3"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="5d66726a-90b1-4b16-b178-0b4bc21b8e3a" id="f996c994-d7fb-495d-a245-b08c8a42b416"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="df238b43-e9fb-4f59-b1e0-bb8e981b24c9" id="3a51586f-4c22-4fc1-ba2b-20628b96d36d"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="2c9ccc8f-7e7b-4c5a-a576-1076f1c075be" id="9260f24e-457d-4374-b08b-16d40a0344ef"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="88da31ff-df5a-48bd-8596-49ac40596943" id="7ab27e01-7f25-438c-84cd-9ac9408097aa"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation3" id="2d81c891-40e7-46c4-bedc-44421085a7a6" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="415.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="f996c994-d7fb-495d-a245-b08c8a42b416" id="5d66726a-90b1-4b16-b178-0b4bc21b8e3a"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation3" id="d6ccc94f-876c-4c6a-9917-8a3fa6975dc2" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="365.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="3a51586f-4c22-4fc1-ba2b-20628b96d36d" id="df238b43-e9fb-4f59-b1e0-bb8e981b24c9"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation3" id="0f2fc1a6-db36-40a4-932f-31d4fddeac42" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="315.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="9260f24e-457d-4374-b08b-16d40a0344ef" id="2c9ccc8f-7e7b-4c5a-a576-1076f1c075be"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation3" id="4ba625a0-78bd-495a-83cd-726f52befcd7" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="265.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="7ab27e01-7f25-438c-84cd-9ac9408097aa" id="88da31ff-df5a-48bd-8596-49ac40596943"/>
-        </asset>
-      </asset>
-      <asset xsi:type="esdl:Building" name="house4" id="0269b285-c826-43fc-be0a-312a3baca12a">
-        <geometry xsi:type="esdl:Point" lat="51.44327392565771" lon="5.326384305953977"/>
-        <asset xsi:type="esdl:EConnection" name="connection4" id="51dd7fc3-323f-4262-b7ef-64c38ba59f8f">
-          <geometry xsi:type="esdl:Point" lat="260.0" lon="52.0" CRS="Simple"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="a98ca5f6-3aec-412a-bc69-a9ca02c63181" id="6fcd6063-0b4f-42b7-b1f2-5a4fcbaf7ec8"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="b1319be4-0ac0-4107-8782-fd6f9b9bb8e4" id="9df13e84-1f73-4ff5-b085-042f135cf124"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="5a8b83a0-418b-41ba-b938-f3fc4ce04bba" id="0ea8d110-a027-49e3-936a-d6c5a30c2cf4"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="49fc9a88-2910-4ab8-8df5-4b85eefd108a" id="6106cdce-8366-4310-8cbb-5e37de41cb40"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="d20f94cf-9e71-4d09-a506-b49dc30ead71" id="06546308-ac87-48f6-956b-a6983614e293"/>
-          <port xsi:type="esdl:InPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="2decec33-402e-48df-a56c-ac7dd0c05b67" id="170be1e2-0004-4ae3-bdfd-a9bf7ac6818e"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation4" id="d4af44ac-aab8-40b3-868c-0668bdb1d9f2" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="415.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="9df13e84-1f73-4ff5-b085-042f135cf124" id="b1319be4-0ac0-4107-8782-fd6f9b9bb8e4"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation4" id="6b22f9d6-c184-4ebf-bfd7-804dd2d56f60" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="365.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="0ea8d110-a027-49e3-936a-d6c5a30c2cf4" id="5a8b83a0-418b-41ba-b938-f3fc4ce04bba"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation4" id="afc87f44-b232-462c-9103-01867dee800b" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="315.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="6106cdce-8366-4310-8cbb-5e37de41cb40" id="49fc9a88-2910-4ab8-8df5-4b85eefd108a"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation4" id="10f2b7e1-0da7-4d46-93a5-696cc01ef07e" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="265.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="06546308-ac87-48f6-956b-a6983614e293" id="d20f94cf-9e71-4d09-a506-b49dc30ead71"/>
-        </asset>
-        <asset xsi:type="esdl:PVInstallation" power="1000.0" name="pv-installation4" id="2ff29e6c-4136-4a12-9dec-85e60d64f990" panelEfficiency="0.2">
-          <geometry xsi:type="esdl:Point" lat="215.0" lon="236.0" CRS="Simple"/>
-          <port xsi:type="esdl:OutPort" carrier="d88696c0-b536-466b-adbf-429f282afeab" connectedTo="170be1e2-0004-4ae3-bdfd-a9bf7ac6818e" id="2decec33-402e-48df-a56c-ac7dd0c05b67"/>
         </asset>
       </asset>
     </area>


### PR DESCRIPTION
fix timing synchronization errors

helics federates are only awekened when new inputs can be read from subscriptions and a time can be granted according to their timing configuration. 
The timing configuration was flawed as federates that published outputs were already being destroyed when other federates were still depending on their inputs.
In addition, federates that expect inputs can be awakened at any time given that all inputs are there.

Hence, calculation services that have inputs will have a period of 0 and a minimum time delta of their period, such that the time step notion can still be maintained.

