### PR TITLE
fix that getting input param returns a wrong value 

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,3 +43,4 @@ jobs:
         python TestInfluxDbWriterLogic.py
         python TestInputExtraction.py
         python TestSimulationRun.py
+        python TestCalculationServiceHelperFunctions.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dots_infrastructure"
-version = "0.4.6"
+version = "0.4.8"
 authors = [
   { name="Leo van Schooten", email="l.g.t.v.schooten@tue.nl" },
 ]

--- a/src/dots_infrastructure/CalculationServiceHelperFunctions.py
+++ b/src/dots_infrastructure/CalculationServiceHelperFunctions.py
@@ -42,7 +42,8 @@ def generate_publications_from_value_descriptions(value_descriptions : List[Publ
 
 def get_single_param_with_name(param_dict : dict, name : str):
     for key in param_dict.keys():
-        if name in key:
+        key_splitted = key.split("/")
+        if any(name == key_part for key_part in key_splitted):
             return param_dict[key]
         
 def clear_dictionary_values(dictionary_to_clear : dict):
@@ -52,4 +53,4 @@ def dictionary_has_values_for_all_keys(dictionary : dict):
     return all([False if v == None else True for v in dictionary.values()])
 
 def get_vector_param_with_name(param_dict : dict, name : str):
-    return [value for key, value in param_dict.items() if name in key]
+    return [value for key, value in param_dict.items() if any(name == key_part for key_part in key.split("/"))]

--- a/test/TestCalculationServiceHelperFunctions.py
+++ b/test/TestCalculationServiceHelperFunctions.py
@@ -1,0 +1,39 @@
+import unittest
+
+from dots_infrastructure.CalculationServiceHelperFunctions import get_single_param_with_name, get_vector_param_with_name
+
+class TestLogicAddingCalculations(unittest.TestCase):
+
+    def test_get_single_param_with_name(self):
+        # Arrange
+        param_dict = {
+            "a/b/active_power": 1,
+            "a/b/reactive_power": 2
+        }
+        name = "active_power"
+
+        # Execute
+        result = get_single_param_with_name(param_dict, name)
+        expected_result = 1
+
+        # Assert
+        self.assertEqual(result, expected_result)
+
+    def test_get_vector_param_with_name(self):
+        # Arrange
+        param_dict = {
+            "a/a/active_power": 1,
+            "a/b/active_power": 2,
+            "a/c/reactive_power": 3
+        }
+        name = "active_power"
+
+        # Execute
+        result = get_vector_param_with_name(param_dict, name)
+        expected_result = [1, 2]
+
+        # Assert
+        self.assertEqual(result, expected_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
fix that getting input param returns a wrong value if parameter name are substrings from each other