### PR TITLE
Bump version from 1.0.8-rc1 to 1.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dots_infrastructure"
-version = "1.0.8-rc1"
+version = "1.0.8"
 authors = [
   { name="Leo van Schooten", email="l.g.t.v.schooten@tue.nl" },
 ]


### PR DESCRIPTION
When the commit is supposed to be a new release on pypi make sure the following checkboxes are checked:
- [x] Update documentation if applicable
- [x] Update `pyproject.toml` with new version number
- [x] Update testcases
